### PR TITLE
Update ConnectionAttempt.cs

### DIFF
--- a/src/Spectre.Client/Data/ConnectionAttempt.cs
+++ b/src/Spectre.Client/Data/ConnectionAttempt.cs
@@ -173,7 +173,7 @@ namespace Spectre.Client
         /// <summary>
         /// Gets or sets the success datetime.
         /// </summary>
-        public DateTime success_at { get; set; }
+        public DateTime? success_at { get; set; }
 
         /// <summary>
         /// Gets or sets the last stage of the connection attempt.


### PR DESCRIPTION
When connection is inactive, the success_at becomes null, so when deserializing it fails.
The alternative is deleting the inactive connection .